### PR TITLE
Use the PSR-2 standard for PHP libraries.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
   "description": "OpenEuropa code review component.",
   "license": "EUPL-1.2",
   "require": {
-    "phpro/grumphp": "~0.12",
-    "phpmd/phpmd" : "^2.6",
     "drupal/coder": "^8.2",
-    "escapestudios/symfony2-coding-standard": "^2.11"
+    "phpmd/phpmd" : "^2.6",
+    "phpro/grumphp": "~0.12",
+    "squizlabs/php_codesniffer": "~3.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.5.0|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "drupal/coder": "^8.2",
     "phpmd/phpmd" : "^2.6",
-    "phpro/grumphp": "~0.12",
+    "phpro/grumphp": "^0.14.1",
     "squizlabs/php_codesniffer": "~3.3"
   },
   "require-dev": {

--- a/dist/base-conventions.yml
+++ b/dist/base-conventions.yml
@@ -11,6 +11,7 @@ parameters:
     - php
   tasks.phpcs.whitelist_patterns: []
   tasks.phpcs.standard: ~
+  tasks.phpcs.warning_severity: ~
 
   # PHP Mess Detector parameters
   tasks.phpmd.exclude:
@@ -34,6 +35,7 @@ parameters:
       ignore_patterns: '%tasks.phpcs.ignore_patterns%'
       triggered_by: '%tasks.phpcs.triggered_by%'
       whitelist_patterns: '%tasks.phpcs.whitelist_patterns%'
+      warning_severity: '%tasks.phpcs.warning_severity%'
       metadata:
         priority: 300
 

--- a/dist/library-conventions.yml
+++ b/dist/library-conventions.yml
@@ -2,4 +2,4 @@ imports:
   - { resource: base-conventions.yml }
 
 parameters:
-  tasks.phpcs.standard: ./vendor/escapestudios/symfony2-coding-standard/Symfony2
+  tasks.phpcs.standard: ./vendor/squizlabs/php_codesniffer/src/Standards/PSR2

--- a/dist/library-conventions.yml
+++ b/dist/library-conventions.yml
@@ -3,3 +3,4 @@ imports:
 
 parameters:
   tasks.phpcs.standard: ./vendor/squizlabs/php_codesniffer/src/Standards/PSR2
+  tasks.phpcs.warning_severity: 0


### PR DESCRIPTION
The Code Review tool is currently using the Symfony2 standard, but it should be using the PSR-2 standard as described in our documentation: [OpenEuropa coding standards for PHP based components](https://github.com/openeuropa/openeuropa/blob/master/docs/development/coding-standards.md#coding-standards-on-php-based-components).

The reason why this PR updates PHP CodeSniffer to version 3.3 is because the directory structure has changed: the standards have moved to the `src/Standards` folder. We are hardcoding a path to the standard in `dist/library-conventions.yml` so this path needs to be correct for the version range that we support. 