### PR TITLE
OPENEUROPA-1160: Remove max length restrictions to commit messages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "OpenEuropa code review component.",
   "license": "EUPL-1.2",
   "require": {
+    "cweagans/composer-patches": "~1.0",
     "drupal/coder": "^8.2",
     "phpmd/phpmd" : "^2.6",
     "phpro/grumphp": "^0.14.1",
@@ -23,6 +24,13 @@
   },
   "scripts": {
     "changelog": "docker run --rm -v \"$(pwd):$(pwd)\" -w $(pwd) muccg/github-changelog-generator openeuropa/code-review -t $CHANGELOG_GITHUB_TOKEN --future-release=$CHANGELOG_FUTURE_RELEASE"
+  },
+  "extra":{
+    "patches": {
+      "phpro/grumphp": {
+        "Remove max length restrictions to commit messages": "https://patch-diff.githubusercontent.com/raw/phpro/grumphp/pull/536.patch"
+      }
+    }
   }
 }
 

--- a/dist/base-conventions.yml
+++ b/dist/base-conventions.yml
@@ -51,3 +51,5 @@ parameters:
       case_insensitive: false
       enforce_no_subject_trailing_period: false
       multiline: false
+      max_body_width: 0
+      max_subject_width: 0


### PR DESCRIPTION
Fixes #32.