### PR TITLE
Description of the git:pre-commit command is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ GrumPHP tasks will be ran at every commit, if you with to run them without perfo
 $ ./vendor/bin/grumphp run
 ```
 
-If you want to simulate a commit message use:
+If you want to simulate the tasks that will be run when creating a new commit:
 
 ```
 $ ./vendor/bin/grumphp git:pre-commit


### PR DESCRIPTION
The description of the `grumphp git:pre-commit` command implies that it will do the checks for the git commit message, but in fact it is doing all the pre-commit checks _except_ the checks for the commit message.