### PR TITLE
OPENEUROPA-1160: Removed the patch as it has been added on last grumphp release, version 0.14.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,6 @@
   },
   "scripts": {
     "changelog": "docker run --rm -v \"$(pwd):$(pwd)\" -w $(pwd) muccg/github-changelog-generator openeuropa/code-review -t $CHANGELOG_GITHUB_TOKEN --future-release=$CHANGELOG_FUTURE_RELEASE"
-  },
-  "extra":{
-    "patches": {
-      "phpro/grumphp": {
-        "Remove max length restrictions to commit messages": "https://patch-diff.githubusercontent.com/raw/phpro/grumphp/pull/536.patch"
-      }
-    }
   }
 }
 


### PR DESCRIPTION
-- The patch which was used to remove the restriction on 60 characters on commit message has been included on the release  0.14.2 grumphp.

-- Due that the patch is not anymore needed.