### PR TITLE
Update GrumPHP to 0.15.x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ pipeline:
 
   composer-install-highest:
     group: prepare
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: ${IMAGE_PHP=fpfis/httpd-php-dev:7.1}
     volumes:
     - /cache:/cache
     commands:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "friendsofphp/php-cs-fixer": "^2.15",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "phpmd/phpmd" : "^2.6",
-        "phpro/grumphp": "^0.14.3",
+        "phpro/grumphp": "~0.15",
         "squizlabs/php_codesniffer": "3.4.2"
     },
     "require-dev": {


### PR DESCRIPTION
When using PHP 7.3 every commit fails due to GrumPHP not being compatible with this PHP version. This is fixed in the 0.15 branch.