### PR TITLE
OPENEUROPA-1897: Use ci image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,14 @@ workspace:
 
 services:
   web:
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:7.1}
+    image: ${IMAGE_PHP=fpfis/httpd-php-ci:7.1}
     environment:
     - DOCUMENT_ROOT=/test/code-review
 
 pipeline:
   composer-install-lowest:
     group: prepare
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:7.1}
+    image: ${IMAGE_PHP=fpfis/httpd-php-ci:7.1}
     volumes:
     - /cache:/cache
     commands:
@@ -22,7 +22,7 @@ pipeline:
 
   composer-install-highest:
     group: prepare
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: ${IMAGE_PHP=fpfis/httpd-php-ci:7.1}
     volumes:
     - /cache:/cache
     commands:
@@ -33,13 +33,13 @@ pipeline:
 
   grumphp:
     group: test
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:7.1}
+    image: ${IMAGE_PHP=fpfis/httpd-php-ci:7.1}
     commands:
     - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:7.1}
+    image: ${IMAGE_PHP=fpfis/httpd-php-ci:7.1}
     commands:
     - ./vendor/bin/phpunit
 


### PR DESCRIPTION
## OPENEUROPA-1897
### Description

Use CI image on drone builds.

### Change log

- Added:
- Changed: Use CI image on drone builds.

- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

