### PR TITLE
OPENEUROPA-627: Update PhpCpdeSniffer to 3.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,24 +188,3 @@ git config --global --unset core.hooksPath
 
 * Best results were gained using the [Docker app](https://docs.docker.com/docker-for-mac/install/)
 * The local repo folder should be shared under Docker -> Preferences -> File sharing to enable the file to be written locally.
-
-## Patches
-
-The component uses the PSR-2 standard based on version 3.4 of package [squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
-As the PSR-2 standard does not enforce indentation, we decided to add custom rules in a custom ruleset in order to make sure
-that our code is properly indented.
-Unfortunately, there are some issues in versions 3.4 of [squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) regarding
-code indentation and we fixed them by including custom patches.
-Those issues are partially solved in version 3.5 which is not stable yet.
-As soon as 3.5 reaches a stable version, we will remove those patches.
-
-When using the Code Review component on your project add the following lines to your `composer.json`:
-
-```
-  "extra": {
-    "composer-exit-on-patch-failure": true,
-    "enable-patching": true
-  }
-```
-
-This will allow Code Review's patches to be correctly applied. 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "drupal/coder": "^8.3.2",
     "phpmd/phpmd" : "^2.6",
     "phpro/grumphp": "^0.15.2",
-    "squizlabs/php_codesniffer": "3.4.2"
+    "squizlabs/php_codesniffer": "^3.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.5|^6.0"
@@ -24,12 +24,7 @@
   },
   "extra": {
     "enable-patching": true,
-    "composer-exit-on-patch-failure": 1,
-    "patches": {
-      "squizlabs/php_codesniffer": {
-        "Disable exact checking of multi-line chained method calls in Generic.WhiteSpace.ScopeIndent. Ref. https://github.com/squizlabs/PHP_CodeSniffer/pull/2372": "https://gist.githubusercontent.com/drupol/c307b48fe4eb187b0833afb1d1b97e6a/raw/c3d414e9f4c182387ca9405c36f5daeb7b51ae05/phpcs-pr-2372.patch"
-      }
-    }
+    "composer-exit-on-patch-failure": 1
   },
   "scripts": {
     "changelog": "docker run --rm -v \"$(pwd):$(pwd)\" -w $(pwd) muccg/github-changelog-generator openeuropa/code-review -t $CHANGELOG_GITHUB_TOKEN --future-release=$CHANGELOG_FUTURE_RELEASE"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "extra": {
     "enable-patching": true,
-    "composer-exit-on-patch-failure": 1
+    "composer-exit-on-patch-failure": true
   },
   "scripts": {
     "changelog": "docker run --rm -v \"$(pwd):$(pwd)\" -w $(pwd) muccg/github-changelog-generator openeuropa/code-review -t $CHANGELOG_GITHUB_TOKEN --future-release=$CHANGELOG_FUTURE_RELEASE"


### PR DESCRIPTION
Require PhpCpdeSniffer  ^3.5, remove merged patch.