### PR TITLE
EWPP: Lock drupal/coder version to 8.3.9.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.2",
     "cweagans/composer-patches": "^1.0",
-    "drupal/coder": "^8.3.4",
+    "drupal/coder": "8.3.9",
     "phpmd/phpmd" : "^2.6",
     "phpro/grumphp": "^0.15.2",
     "squizlabs/php_codesniffer": "^3.5"


### PR DESCRIPTION
Lock drupal/coder to version 8.3.9 because of false array declaration character limit detection.
![image](https://user-images.githubusercontent.com/22004498/92373636-e6a2a680-f0fe-11ea-9c37-d53f15fde560.png)
![image](https://user-images.githubusercontent.com/22004498/92373671-f6ba8600-f0fe-11ea-87c4-1b15a4c9b4be.png)
As we can see on the screenshot the red line represents the 80 char limit and such array declaration with a single element should not be a blocker in this case.